### PR TITLE
SFX_AUTOJOY: Add support for joypad 3 & 4 and all possible joypad configurations

### DIFF
--- a/libSFX/CPU/Runtime.s
+++ b/libSFX/CPU/Runtime.s
@@ -78,14 +78,16 @@ VBlankVector:
         jsl     SFX_nmi_jml             ;Call trampoline
 .endif
 
-.if SFX_AUTOJOY = ENABLE
+.if SFX_AUTOJOY <> DISABLE
         RW a8
-:       lda     HVBJOY                  ;Wait for joystick readout
+:       lda     HVBJOY                  ;Wait for joypad readout
         and     #1
         bne     :-
 
         RW a16i16
-        ldx     JOY1L                   ;Read controller 1
+.endif
+.if SFX_AUTOJOY & JOY1
+        ldx     JOY1L                   ;Read joypad 1
         txa
         eor     a:SFX_joy1cnt
         sta     a:SFX_joy1trg
@@ -93,8 +95,9 @@ VBlankVector:
         and     a:SFX_joy1trg
         sta     a:SFX_joy1trg
         stx     a:SFX_joy1cnt
-
-        ldx     JOY2L                   ;Read controller 2
+.endif
+.if SFX_AUTOJOY & JOY2
+        ldx     JOY2L
         txa
         eor     a:SFX_joy2cnt
         sta     a:SFX_joy2trg
@@ -102,6 +105,26 @@ VBlankVector:
         and     a:SFX_joy2trg
         sta     a:SFX_joy2trg
         stx     a:SFX_joy2cnt
+.endif
+.if SFX_AUTOJOY & JOY3
+        ldx     JOY3L
+        txa
+        eor     a:SFX_joy3cnt
+        sta     a:SFX_joy3trg
+        txa
+        and     a:SFX_joy3trg
+        sta     a:SFX_joy3trg
+        stx     a:SFX_joy3cnt
+.endif
+.if SFX_AUTOJOY & JOY4
+        ldx     JOY4L
+        txa
+        eor     a:SFX_joy4cnt
+        sta     a:SFX_joy4trg
+        txa
+        and     a:SFX_joy4trg
+        sta     a:SFX_joy4trg
+        stx     a:SFX_joy4cnt
 .endif
 
 .if SFX_AUTOJOY_FIRST = YES
@@ -183,11 +206,21 @@ SFX_mvn_dst:    .res 1          ;  Destination bank
 SFX_mvn_src:    .res 1          ;  Source bank
 SFX_mvn_rtl:    .res 1          ;  Return
 
-.if SFX_AUTOJOY = ENABLE
+.if SFX_AUTOJOY & JOY1
 SFX_joy1cnt:    .res 2
 SFX_joy1trg:    .res 2
+.endif
+.if SFX_AUTOJOY & JOY2
 SFX_joy2cnt:    .res 2
 SFX_joy2trg:    .res 2
+.endif
+.if SFX_AUTOJOY & JOY3
+SFX_joy3cnt:    .res 2
+SFX_joy3trg:    .res 2
+.endif
+.if SFX_AUTOJOY & JOY4
+SFX_joy4cnt:    .res 2
+SFX_joy4trg:    .res 2
 .endif
 
 ;Reserve ZPAD (ZEROPAGE scratchpad)

--- a/libSFX/CPU_Runtime.i
+++ b/libSFX/CPU_Runtime.i
@@ -1,13 +1,19 @@
 ; libSFX S-CPU NMI/IRQ Vector Macros
 ; David Lindecrantz <optiroc@gmail.com>
 
+
 .ifndef ::__MBSFX_CPU_Runtime__
 ::__MBSFX_CPU_Runtime__ = 1
 
 ;Default settings for joypad polling
 .ifndef SFX_AUTOJOY
-    SFX_AUTOJOY = ENABLE
+    SFX_AUTOJOY = JOY1 | JOY2
 .endif
+
+.if (SFX_AUTOJOY < 0) || (SFX_AUTOJOY > (JOY1 | JOY2 | JOY3 | JOY4))
+    SFX_error "SFX_AUTOJOY: Bad configuration"
+.endif
+
 .ifndef SFX_AUTOJOY_FIRST
     SFX_AUTOJOY_FIRST = NO
 .endif
@@ -20,8 +26,17 @@
 .globalzp SFX_tick, SFX_jml, SFX_addr, SFX_word
 .globalzp SFX_mvn, SFX_mvn_dst, SFX_mvn_src
 
-.if SFX_AUTOJOY = ENABLE
-.globalzp SFX_joy1cnt, SFX_joy1trg, SFX_joy2cnt, SFX_joy2trg
+.if SFX_AUTOJOY & JOY1
+.globalzp SFX_joy1cnt, SFX_joy1trg
+.endif
+.if SFX_AUTOJOY & JOY2
+.globalzp SFX_joy2cnt, SFX_joy2trg
+.endif
+.if SFX_AUTOJOY & JOY3
+.globalzp SFX_joy3cnt, SFX_joy3tr
+.endif
+.if SFX_AUTOJOY & JOY4
+.globalzp SFX_joy3cnt, SFX_joy3tr
 .endif
 
 ;-------------------------------------------------------------------------------

--- a/libSFX/Configurations/libSFX.cfg
+++ b/libSFX/Configurations/libSFX.cfg
@@ -72,12 +72,15 @@ ROM_COUNTRY = $00
 ;--------------------------------------------------------------------
 ;libSFX Settings
 
-;Automatic joypad read-out (*YES*/NO)
+;Automatic joypad read-out
+;  Bitwise OR each joypad to be read: `JOY1`, `JOY2`, `JOY3`, `JOY4`
+;  Disable by setting `SFX_AUTOJOY` to `DISABLE`
 ;  Read joypad bits from zero-page locations:
-;  SFX_joy1trg, SFX_joy1cnt and SFX_joy2trg, SFX_joy2cnt
+;  `SFX_joy1trg`, `SFX_joy1cnt`, `SFX_joy2trg`, `SFX_joy2cnt`,
+;  `SFX_joy3trg`, `SFX_joy3cnt`, `SFX_joy4trg`, `SFX_joy4cnt`
 ;  *trg = bits are on during one frame when buttons are triggered
 ;  *cnt = bits are held continously as long as buttons are pushed
-SFX_AUTOJOY = YES
+SFX_AUTOJOY = JOY1 | JOY2
 
 ;Perform joypad readout before calling soft NMI (YES/*NO*)
 ;  NO (default) will call NMI trampoline before automatic joypad read

--- a/libSFX/Meta.i
+++ b/libSFX/Meta.i
@@ -11,6 +11,11 @@
 .define ENABLE          1
 .define DISABLE         0
 
+.define JOY1    %00000001
+.define JOY2    %00000010
+.define JOY3    %00000100
+.define JOY4    %00001000
+
 .macro SFX_warning description
   .assert 0, warning, description
 .endmac


### PR DESCRIPTION
Hi,

This adds support for the other two joypads, as well as an API for reading any possible combination of joypads via SFX_AUTOJOY.

Thanks!
Kyle
