### PR TITLE
libSFX.cfg: add ROM_GAMECODE and ROM_MAKERCODE

### DIFF
--- a/libSFX/Configurations/libSFX.cfg
+++ b/libSFX/Configurations/libSFX.cfg
@@ -61,6 +61,14 @@ ROM_ROMSIZE = $07
 ;  ...etc
 ROM_RAMSIZE = $00
 
+;ROM_GAMECODE (4 chars)
+;                         "1234"
+define "ROM_GAMECODE",    "SFXJ"
+
+;ROM_MAKERCODE (2 chars)
+;                          "12"
+define "ROM_MAKERCODE",    "MB"
+
 ;Software minor version
 ROM_VERSION = $00
 


### PR DESCRIPTION
Noticed that `ROM_GAMECODE` and `ROM_MAKERCODE` were missing from the configuration file. Thanks!
