### PR TITLE
SMP_playspc: SFX_error when ROM_MAPMODE == 0 and ram_hi parameter is …

### DIFF
--- a/include/CPU_SMP.i
+++ b/include/CPU_SMP.i
@@ -93,6 +93,9 @@ SFX_SPC_IMAGE = EXRAM   ;SPC image dump location for SFX_APU_execspc
   :in?:   ram_hi  Address to upper 32kB SPC RAM dump (uint24) constant
 */
 .macro  SMP_playspc state, ram, ram_hi
+  .if ((ROM_MAPMODE = $0) && (.blank({ram_hi})))
+        SFX_error "SMP_playspc: If ROM_MAPMODE == 0 (`LoROM`) both ram and ram_hi parameters are required."
+  .endif
   .if .blank({ram_hi})
         WRAM_memcpy SFX_SPC_IMAGE, ram, $0000
         WRAM_memcpy SFX_DSP_STATE, state, $100


### PR DESCRIPTION
Clearing a couple of random things from local branches. I've got a bunch of cool SMP/DSP stuff in the works, but it's late and it still needs a little bit of polish, so here's some bike shedding. There's probably a few other macros that could use either an `SFX_warning` or `SFX_error`. Better to let the assembler catch this kind of stuff, I think.
