### PR TITLE
SFX_SMP_waitReady => SFX_SMP_ready

### DIFF
--- a/include/CPU_SMP.i
+++ b/include/CPU_SMP.i
@@ -17,7 +17,7 @@ SFX_SPC_IMAGE = EXRAM   ;SPC image dump location for SFX_APU_execspc
 */
 .macro  SMP_ready
         RW_push set:i16
-        jsl     SFX_SMP_waitReady
+        jsl     SFX_SMP_ready
         RW_pull
 .endmac
 


### PR DESCRIPTION
This macro has a misnamed subroutine. Referenced everywhere else as `SFX_SMP_ready`.
