### PR TITLE
RW and other macro scope fixes and stuff

### DIFF
--- a/include/CPU.i
+++ b/include/CPU.i
@@ -38,15 +38,82 @@
 
   The 'external' subroutine looks like this:
 
-  .proc external
-        RW_assume a16               ;16 bit accumulator is assumed
-                                    ;(no instruction emitted)
+  proc external, a16                ;16 bit accumulator is assumed (no instruction emitted)
         lda     #$f00d              ;So this will assemble nicely
         rtl
-  .endproc
+  endproc
   (end)
 */
 
+/**
+  Macro: proc
+  Define procedure with separate RW state
+  
+  This is equivalent to .proc directive, but ensures that using the RW*
+  macros inside of the procedure does not affect tracking of CPU state anywhere
+  outside of the procedure, and vice-versa.
+  
+  It is recommended to use the 'proc' and 'endproc' macros instead of .proc and
+  .endproc for any code using libSFX macros.
+  
+  By default, code inside the procedure assumes 8-bit A and 16-bit X/Y (M=1, X=0).
+  Optionally, you may specify other incoming register sizes as a parameter.
+  (See also: 'RW_init', 'RW_assume')
+  
+  Parameter:
+  >:in:    name      Procedure name
+  >:in?:   widths    Register widths         a8/a16/i8/i16/a8i8/a16i16/a8i16/a16i8
+*/
+.macro proc name, widths
+  RW_push ; save .a8/.a16/etc so ca65 can remember them later
+  .proc name
+  RW_init ; create new RW state in this scope
+  .ifnblank widths
+    RW_assume widths ; create new RW state with initial values
+  .endif
+.endmac
+
+/**
+  Macro: endproc
+  End procedure and restore RW state
+  
+  This is the equivalent to .endproc corresponding with the 'proc' macro.
+  This ensures that the outer scope continues to track the correct register
+  sizes regardless of any RW* macros which were used in the inner scope.
+*/
+.macro endproc
+  .endproc
+  RW_pull ; check previous RW state in outer scope so ca65 can be reminded what the widths were
+.endmac
+
+/**
+  Macro: RW_init
+  Define RW state variables in current scope
+  
+  Used by all register width macros to ensure that register state can be tracked
+  in any scope. This also means that code inside of a .proc or .scope will not
+  affect tracked register widths for code in the global scope, and vice-versa.
+  (Thus, the register widths inside a nested scope are always initially a8i16.)
+*/
+.macro RW_init
+  .if !.const(SFX_RW_init)
+    SFX_RW_init .set 1
+    
+    ;Initial register widths
+    RW_assume a8i16
+	
+    ;RW stack (bit 0 = accumulator size, bit 1 = index size)
+    SFX_RW_size_sp .set 0
+    SFX_RW_size_s1 .set %00
+    SFX_RW_size_s2 .set %00
+    SFX_RW_size_s3 .set %00
+    SFX_RW_size_s4 .set %00
+    SFX_RW_size_s5 .set %00
+    SFX_RW_size_s6 .set %00
+    SFX_RW_size_s7 .set %00
+    SFX_RW_size_s8 .set %00
+  .endif
+.endmac
 
 /**
   Macro: RW
@@ -61,6 +128,7 @@
 .if .blank({widths})
   SFX_error "RW: Missing required parameter"
 .else
+  RW_init
   .if .xmatch({widths},{a8})
     .if SFX_RW_a_size <> 1
       sep #$20
@@ -110,6 +178,7 @@
 .if .blank({widths})
   SFX_error "RW_assume: Missing required parameter"
 .else
+  RW_init
   .if .xmatch({widths},{a8})
     SFX_RW_a_size .set 1
     .a8
@@ -183,6 +252,7 @@
 .if .blank({message})
   SFX_error "RW_assert: Missing required parameter(s)"
 .else
+  RW_init
   .if .xmatch({widths},{a8})
     .if SFX_RW_a_size <> 1
       SFX_error message
@@ -208,11 +278,11 @@
       SFX_error message
     .endif
   .elseif .xmatch({widths},{a8i16})
-    RW_assert a8 message
-    RW_assert i16 message
+    RW_assert a8, message
+    RW_assert i16, message
   .elseif .xmatch({widths},{a16i8})
-    RW_assert a16 message
-    RW_assert i8 message
+    RW_assert a16, message
+    RW_assert i8, message
   .else
     SFX_error "RW_assert: Illegal parameter"
   .endif
@@ -231,10 +301,10 @@
   >:in?:   widths    Register widths         a8/a16/i8/i16/a8i8/a16i16/a8i16/a16i8
 */
 .macro RW_push new
+  RW_init
 .if SFX_RW_size_sp = 8
   SFX_error "RW_push: RW stack overflow"
 .endif
-
   SFX_RW_size_sp .set SFX_RW_size_sp+1
 
   _sizeval_ .set %00
@@ -293,10 +363,10 @@
   No-op if current state == intended state.
 */
 .macro RW_pull
+  RW_init
 .if SFX_RW_size_sp = 0
   SFX_error "RW_pull: RW stack underflow"
 .endif
-
   .if SFX_RW_size_sp = 0
     _sizeval_ .set $ff
   .elseif SFX_RW_size_sp = 1
@@ -342,10 +412,10 @@
   with the register widths in an unknown state.
 */
 .macro RW_pull_forced
+  RW_init
 .if SFX_RW_size_sp = 0
   SFX_error "RW_pull_forced: RW stack underflow"
 .endif
-
   .if SFX_RW_size_sp = 0
     _sizeval_ .set $ff
   .elseif SFX_RW_size_sp = 1
@@ -386,16 +456,16 @@
   Print (at assemble time) the current register widths state
 */
 .macro RW_print
-  .if SFX_RW_a_size = 0
+  .if .const(SFX_RW_a_size) .and SFX_RW_a_size = 0
     .out "Accumulator size = 0 (16-bit)"
-  .elseif SFX_RW_a_size = 1
+  .elseif .const(SFX_RW_a_size) .and  SFX_RW_a_size = 1
     .out "Accumulator size = 1 (8-bit)"
   .else
     .out "Accumulator size undefined (!)"
   .endif
-  .if SFX_RW_i_size = 0
+  .if .const(SFX_RW_i_size) .and SFX_RW_i_size = 0
     .out "Index size = 0 (16-bit)"
-  .elseif SFX_RW_i_size = 1
+  .elseif .const(SFX_RW_i_size) .and SFX_RW_i_size = 1
     .out "Index size = 1 (8-bit)"
   .else
     .out "Index size undefined (!)"
@@ -422,22 +492,6 @@
   >1 = 8 bits
 */
 .define RW_i_size SFX_RW_i_size
-
-
-;Book-keeping variables
-SFX_RW_a_size .set 1
-SFX_RW_i_size .set 0
-
-;RW stack (bit 0 = accumulator size, bit 1 = index size)
-SFX_RW_size_sp .set 0
-SFX_RW_size_s1 .set %00
-SFX_RW_size_s2 .set %00
-SFX_RW_size_s3 .set %00
-SFX_RW_size_s4 .set %00
-SFX_RW_size_s5 .set %00
-SFX_RW_size_s6 .set %00
-SFX_RW_size_s7 .set %00
-SFX_RW_size_s8 .set %00
 
 
 ;-------------------------------------------------------------------------------
@@ -679,7 +733,7 @@ SFX_dp_offset .set 0
   which can be set to trigger a break in the bsnes+ debugger.
 */
 .macro break
-  .ifdef __DEBUG__
+  .ifdef ::__DEBUG__
         wdm     $00
   .endif
 .endmac

--- a/include/CPU_Runtime.i
+++ b/include/CPU_Runtime.i
@@ -131,7 +131,7 @@
 .macro  VBL_on
         RW_push set:a8
         lda     SFX_nmitimen
-.if SFX_AUTO_READOUT <> DISABLE
+.if ::SFX_AUTO_READOUT <> DISABLE
         ora     #NMI_NMI_ON + NMI_JOY_ON
 .else
         ora     #NMI_NMI_ON
@@ -255,7 +255,7 @@
         lda     #$0000                  ;Set direct page at $0000
         tcd
         RW a8
-  .if ROM_MAPMODE <> 1
+  .if ::ROM_MAPMODE <> 1
         phk                             ;If not Mode 21: Set DB to same as PC bank
         plb
   .else

--- a/include/CPU_SMP.i
+++ b/include/CPU_SMP.i
@@ -140,7 +140,7 @@ SFX_SPC_IMAGE = EXRAM
   (end)
 */
 .macro  SMP_playspc state, ram, ram_hi
-  .if ((ROM_MAPMODE = $0) && (.blank({ram_hi})))
+  .if ((::ROM_MAPMODE = $0) && (.blank({ram_hi})))
         SFX_error "SMP_playspc: If ROM_MAPMODE == 0 (`LoROM`) both ram and ram_hi parameters are required."
   .endif
   .if .blank({ram_hi})
@@ -192,7 +192,7 @@ SFX_SPC_IMAGE = EXRAM
   >:in:    filename  SPC File                path
 */
 .macro SPC_incbin_hi filename
-        .incbin spc_file, $8100, $8000  ;$8000-$ffff SMP RAM
+        .incbin filename, $8100, $8000  ;$8000-$ffff SMP RAM
 .endmac
 
 /**

--- a/include/libSFX.i
+++ b/include/libSFX.i
@@ -100,7 +100,7 @@
   .endif
 
   ;Initial register widths
-  RW_assume a8i16
+  RW_init
 
 .endif
 


### PR DESCRIPTION
Following on from #11, here is some stuff which:

* defines `proc` and `endproc` macros to handle scoping of register size macros etc.
* defines `RW_init` macro to help define default register sizes in the current scope whenever needed
* explicitly specifies the global scope for some symbols (`__DEBUG__`, `ROM_MAPMODE` etc.) that affect macro expansion
* fixes some unrelated syntax errors in a couple of macros

The new RW changes mean that you can now define procedures or scopes with register width tracking that's independent of the normal global scope. The regular `.proc` and `.endproc` should also work but you'll have to `RW_push` and `RW_pull` yourself to make sure ca65 still remembers what size immediate instructions are supposed to be.

The other changes (re: explicit scoping) should just make it possible to use other libSFX macros inside a nested scope without those pesky non-const symbol problems. I didn't test this quite as extensively so I might have missed a spot. (Anything defined with the `define` macro should be fine. I haven't tested the FIFO/FILO stuff though)

some example test code:

```asm
.include "libSFX.i"

;-------------------------------------------------------------------------------
.segment "CODE"

RW_assert a8i16, "default RW wasn't a8i16"
:	lda #0
.assert (*-(:-)) = 2, error, "lda #0 w/ a8 was wrong size"
:	ldx #0
.assert (*-(:-)) = 3, error, "ldx #0 w/ i16 was wrong size"

; set future global scope state to a8i8
RW i8

; but first...
proc test, a16i8

RW_assert a16i8, "default RW in scope wasn't a16i8"
:	lda #NMI_NMI_MASK
.assert (*-(:-)) = 3, error, "lda #0 w/ a16 was wrong size"
:	ldx #0
.assert (*-(:-)) = 2, error, "ldx #0 w/ i8 was wrong size"

; this should be cancelled out after ending this scope
RW_push set:a16i16

endproc

; RW should now be a8i8 like we set it before the proc

RW_assert a8i8, "after proc RW wasn't a8i8"
:	lda #0
.assert (*-(:-)) = 2, error, "lda #0 w/ a8 was wrong size"
:	ldx #0
.assert (*-(:-)) = 2, error, "ldx #0 w/ i8 was wrong size"
```
