### PR TITLE
add optional params to incbin macro

### DIFF
--- a/include/libSFX.defines.i
+++ b/include/libSFX.defines.i
@@ -36,10 +36,18 @@
 
   :in:    name    Name         identifier
   :in:    file    Filename     string
+  :in?:   offset  File offset  constant
+  :in?:   size    Data size    constant
 */
-.macro incbin name, file
+.macro incbin name, file, offset, size
   .ident(.sprintf("%s", .string(name))):
-  .incbin file
+  .if .not .blank(size)
+    .incbin file, offset, size
+  .elseif .not .blank(offset)
+    .incbin file, offset
+  .else
+    .incbin file
+  .endif
   .ident(.sprintf("sizeof_%s", .string(name))) = * - .ident(.sprintf("%s", .string(name)))
 .endmac
 


### PR DESCRIPTION
Sorry, more PRs :)

This just gives the `incbin` macro the same optional params as the real thing.