### PR TITLE
be safer about DB value with NMI/IRQ/MVN/MVP

### DIFF
--- a/include/CPU/Runtime.s
+++ b/include/CPU/Runtime.s
@@ -67,9 +67,10 @@ VBlankVector:
 :       push
 
         dpage   $0000
-        inc     a:SFX_tick              ;Global frame ticker
+        inc     z:SFX_tick              ;Global frame ticker
 
         RW a8
+        dbank   $80
         lda     RDNMI                   ;Clear NMI
         lda     #inidisp(OFF, DISP_BRIGHTNESS_MIN)
         sta     INIDISP
@@ -134,10 +135,10 @@ VBlankVector:
 .endif
 
         RW a8
-        lda     a:SFX_nmitimen          ;Set IRQ flags
+        lda     z:SFX_nmitimen          ;Set IRQ flags
         sta     NMITIMEN
 
-        lda     a:SFX_inidisp           ;Restore screen and return
+        lda     z:SFX_inidisp           ;Restore screen and return
         sta     INIDISP
 
         pull
@@ -157,7 +158,7 @@ IRQVector:
         jml     :+                      ;Jump to fast mirror
 :       push
         RW a8
-        lda     TIMEUP                  ;Acknowledge IRQ
+        lda     f:TIMEUP                ;Acknowledge IRQ
         jsl     SFX_irq_jml             ;Call trampoline
         pull
         rti

--- a/include/CPU_Memory.i
+++ b/include/CPU_Memory.i
@@ -141,7 +141,7 @@
   SFX_error "memcpy: Missing required parameter(s)"
 .else
         RW_push set:i16
-
+        phb
   .if (.xmatch({dest},{ay}) .or .xmatch({source},{ax}))
     ;Using 'a' as bank pointer, set that right away so 'a' can safely be modified later
         RW a8
@@ -211,7 +211,6 @@
     .endif
         jsl     SFX_mvn
   .endif
-        phk
         plb
         RW_pull
 .endif


### PR DESCRIPTION
One other thing I ran into while working on you-know-what but I forgot to commit earlier: currently the NMI/IRQ handlers assume that DB is currently pointing at a LoROM bank, which may not be true for a variety of reasons (including if a MVN/MVP instruction is currently in progress).

NMI now switches to bank $80, IRQ leaves DB alone but uses a long address when reading TIMEUP (maybe they should both set DB? I don't know)

Also, memcpy now pushes the existing DB value instead of assuming it had been the same as the current program bank.