### PR TITLE
Fix banks on memcpy instruction

### DIFF
--- a/include/CPU_Memory.i
+++ b/include/CPU_Memory.i
@@ -169,17 +169,17 @@
         .if (.loword(source) >= .loword(dest))
           ldx     #.loword(source)
           ldy     #.loword(dest)
-          mvn     ^(source), ^(dest)
+          mvn     #^(source), #^(dest)
         .else
           ldx     #.loword(source)+length-1
           ldy     #.loword(dest)+length-1
-          mvp     ^(source), ^(dest)
+          mvp     #^(source), #^(dest)
         .endif
       .else
         ;Addresses not known - mvn is the best bet
           ldx     #.loword(source)
           ldy     #.loword(dest)
-          mvn     ^(source), ^(dest)
+          mvn     #^(source), #^(dest)
       .endif
     .else
       ;Addresses in registers - use mvn


### PR DESCRIPTION
returns "mvn $00 $00" unless not addresses, as shown.